### PR TITLE
hwpf: fix missing init of csr_throttle_q on reset

### DIFF
--- a/rtl/src/hwpf_stride/hwpf_stride.sv
+++ b/rtl/src/hwpf_stride/hwpf_stride.sv
@@ -157,6 +157,7 @@ import hpdcache_pkg::*;
         if (!rst_ni) begin
             csr_base_q <= '0;
             csr_param_q <= '0;
+            csr_throttle_q <= '0;
             shadow_base_q <= '0;
             shadow_param_q <= '0;
             shadow_throttle_q <= '0;


### PR DESCRIPTION
Fixes issue #149