### PR TITLE
Fix CMO prefetch handling of pma uncacheable

### DIFF
--- a/rtl/src/hpdcache_ctrl.sv
+++ b/rtl/src/hpdcache_ctrl.sv
@@ -504,7 +504,8 @@ import hpdcache_pkg::*;
     end
 
     //     Decode operation in stage 0
-    assign st0_req_is_uncacheable  = ~cfg_enable_i ? 1'b1 :
+    assign st0_req_is_uncacheable  = st0_req.err_scrubbing ? 1'b0 :
+                                     ~cfg_enable_i ? 1'b1 :
                                      st0_req_is_cmo_prefetch ? 1'b0 :
                                      st0_req.req.pma.uncacheable;
     assign st0_req_is_load         = is_load(st0_req.req.op) & ~st0_req.err_scrubbing;

--- a/rtl/src/hpdcache_ctrl.sv
+++ b/rtl/src/hpdcache_ctrl.sv
@@ -504,7 +504,9 @@ import hpdcache_pkg::*;
     end
 
     //     Decode operation in stage 0
-    assign st0_req_is_uncacheable  = st0_req.req.pma.uncacheable;
+    assign st0_req_is_uncacheable  = ~cfg_enable_i ? 1'b1 :
+                                     st0_req_is_cmo_prefetch ? 1'b0 :
+                                     st0_req.req.pma.uncacheable;
     assign st0_req_is_load         = is_load(st0_req.req.op) & ~st0_req.err_scrubbing;
     assign st0_req_is_scrub        = is_load(st0_req.req.op) &  st0_req.err_scrubbing;
     assign st0_req_is_store        = is_store(st0_req.req.op);
@@ -555,7 +557,9 @@ import hpdcache_pkg::*;
     //         previous cycle (stage 0). Useful in case of TLB miss for example
     assign st1_req_abort = core_req_abort_i & ~st1_req.req.phys_indexed;
 
-    assign st1_req_is_uncacheable = ~cfg_enable_i | st1_req.req.pma.uncacheable;
+    assign st1_req_is_uncacheable = ~cfg_enable_i ? 1'b1 :
+                                    st1_req_is_cmo_prefetch ? 1'b0 :
+                                    st1_req.req.pma.uncacheable;
 
     assign st1_req_is_load  = is_load(st1_req.req.op) & ~st1_req.err_scrubbing;
     assign st1_req_is_store = is_store(st1_req.req.op);


### PR DESCRIPTION
Hi,

Based on #151, this PR proposes one possible way to handle CMO prefetch with `pma.uncacheable`.

The proposed behavior is:

* When `cfg_enable_i = 0`, fence/invalidate/flush can still be handled normally, while prefetch remains load-like and is forced to the uncacheable path, which results in an error.
* When `cfg_enable_i = 1`, the three other CMO operations keep their current behavior, and prefetch could also treat `pma.uncacheable` as Don't Care, consistent with the specification.

This change implements that interpretation by ignoring `pma.uncacheable` for prefetch only when the cache is enabled.

Could you please confirm whether this matches the intended behavior, or whether prefetch is intentionally expected to be treated differently from the other CMO operations?

Thanks.